### PR TITLE
Implement skeleton for profile page

### DIFF
--- a/static/profile_view/style.css
+++ b/static/profile_view/style.css
@@ -13,6 +13,9 @@ nav {
     display: flex;
     justify-content: space-between;
 }
+nav ul li a:hover {
+    color: papayawhip;
+}
 .operation li, .account li{
     display: inline;
     margin: 10px;

--- a/static/profile_view/style.css
+++ b/static/profile_view/style.css
@@ -5,9 +5,31 @@ body {
     padding: 0;
     background-color: #f4f4f9;
 }
-
+header {
+    background-color: black;
+    width: 100%;
+}
+nav {
+    display: flex;
+    justify-content: space-between;
+}
+.operation li, .account li{
+    display: inline;
+    margin: 10px;
+}
+.information {
+    display: flex;
+    justify-content: space-between;
+}
+.information li {
+    display: inline;
+}
+li a {
+    color: white;
+    text-decoration: none;
+}
 .container {
-    max-width: 400px;
+    max-width: 95%;
     margin: 50px auto;
     padding: 20px;
     background: #ffffff;
@@ -20,18 +42,4 @@ h2 {
     text-align: center;
     color: #333;
     margin-bottom: 20px;
-}
-
-/* LogoutLink */
-.logout-link {
-    display: block;
-    text-align: center;
-    margin-top: 20px;
-    color: #007bff;
-    text-decoration: none;
-    font-weight: bold;
-}
-
-.logout-link:hover {
-    color: #0056b3;
 }

--- a/templates/profile_view/profile.html
+++ b/templates/profile_view/profile.html
@@ -20,7 +20,7 @@
                 {% endif %}
             </ul>
             <ul class="account">
-                <li><a href="/">{{ username }}</a> </li>
+                <li><a href="/">{{ request_username }}</a> </li>
                 <li><a href="{% url 'logout' %}">Logout</a></li>
             </ul>
         </nav>
@@ -51,7 +51,7 @@
             {% endif %}
             {% if isAdmin or self %}
             <li>
-                <p><a href="#" style="color: blue">Edit</a></p>
+                <p><a href="{% if not self %}/create-user/{{ username }}{% endif %}" style="color: blue">Edit</a></p>
             </li>
             {% endif %}
         </ul>

--- a/templates/profile_view/profile.html
+++ b/templates/profile_view/profile.html
@@ -8,26 +8,56 @@
     <link rel="stylesheet" href="{% static 'profile_view/style.css' %}">
 </head>
 <body>
+    <header>
+        <nav>
+            <ul class="operation">
+                <li><a href="#">Explorer</a></li>
+                <li><a href="#">Notification</a></li>
+                <li><a href="/create-section/">+ Add Section</a></li>
+                {% if isAdmin%}
+                    <li><a href="/create-course/">+ Add Course</a></li>
+                    <li><a href="/create-user/">Create User</a></li>
+                {% endif %}
+            </ul>
+            <ul class="account">
+                <li><a href="/">{{ username }}</a> </li>
+                <li><a href="{% url 'logout' %}">Logout</a></li>
+            </ul>
+        </nav>
+    </header>
     <div class="container">
-        <h2>Welcome, {{ user_profile.name }}!</h2>
-        <p><strong>Email:</strong> {{ user_profile.email }}</p>
-        <p><strong>Role:</strong> {{ user_profile.role }}</p>
-        
-        {% if user_profile.office_hours %}
-            <p><strong>Office Hours:</strong> {{ user_profile.office_hours }}</p>
-        {% endif %}
-        
-        <p><strong>Courses:</strong> {{ user_profile.courses_assigned }}</p>
-
-        {% if user_profile.address %}
-            <p><strong>Address:</strong> {{ user_profile.address }}</p>
-        {% endif %}
-
-        {% if user_profile.phone %}
-            <p><strong>Phone:</strong> {{ user_profile.phone }}</p>
-        {% endif %}
-
-        <a class="logout-link" href="{% url 'logout' %}">Logout</a>
+        <ul class="information">
+            <li>
+                <p style="font-size: 30px; font-family: 'Times New Roman';"><strong>{{ user_profile.name }}</strong></p>
+                <p>{{ user_profile.role }}</p>
+            </li>
+            {% if user_profile.email %}
+            <li>
+                <p>Email</p>
+                <p style="font-family: 'Times New Roman'">{{ user_profile.email }}</p>
+            </li>
+            {% endif %}
+            {% if user_profile.phone %}
+            <li>
+                <p>Phone</p>
+                <p style="font-family: 'Times New Roman'">{{ user_profile.phone }}</p>
+            </li>
+            {% endif %}
+            {% if user_profile.address %}
+            <li>
+                <p>Address</p>
+                <p style="font-family: 'Times New Roman'">{{ user_profile.address }}</p>
+            </li>
+            {% endif %}
+            {% if isAdmin or self %}
+            <li>
+                <p><a href="#" style="color: blue">Edit</a></p>
+            </li>
+            {% endif %}
+        </ul>
+        <div class="Course">
+            <p><strong>Courses:</strong> {{ user_profile.courses_assigned }}</p>
+        </div>
     </div>
 </body>
 </html>

--- a/templates/profile_view/profile.html
+++ b/templates/profile_view/profile.html
@@ -51,7 +51,7 @@
             {% endif %}
             {% if isAdmin or self %}
             <li>
-                <p><a href="{% if not self %}/create-user/{{ username }}{% endif %}" style="color: blue">Edit</a></p>
+                <p><a href="{% if not self and isAdmin %}/create-user/{{ username }}{% endif %}" style="color: blue">Edit</a></p>
             </li>
             {% endif %}
         </ul>

--- a/templates/profile_view/profile.html
+++ b/templates/profile_view/profile.html
@@ -13,14 +13,13 @@
             <ul class="operation">
                 <li><a href="#">Explorer</a></li>
                 <li><a href="#">Notification</a></li>
-                <li><a href="/create-section/">+ Add Section</a></li>
                 {% if isAdmin%}
                     <li><a href="/create-course/">+ Add Course</a></li>
-                    <li><a href="/create-user/">Create User</a></li>
+                    <li><a href="/create-user/">+ Create User</a></li>
                 {% endif %}
             </ul>
             <ul class="account">
-                <li><a href="/">{{ request_username }}</a> </li>
+                <li><a href="/">{{ full_name }}</a> </li>
                 <li><a href="{% url 'logout' %}">Logout</a></li>
             </ul>
         </nav>
@@ -51,7 +50,7 @@
             {% endif %}
             {% if isAdmin or self %}
             <li>
-                <p><a href="{% if not self and isAdmin %}/create-user/{{ username }}{% endif %}" style="color: blue">Edit</a></p>
+                <p><a href="/create-user/{{ username }}" style="color: blue">Edit</a></p>
             </li>
             {% endif %}
         </ul>

--- a/views/profile_view/views.py
+++ b/views/profile_view/views.py
@@ -44,7 +44,7 @@ class ProfileView(View):
             'user_profile': user_profile,
             'isAdmin': request.user.role == 'Admin',
             'self': username == None,
-            'username': "" if username is None else username,
+            'username': request.user.username if username is None else username,
         }
 
         return render(request, 'profile_view/profile.html', context)

--- a/views/profile_view/views.py
+++ b/views/profile_view/views.py
@@ -39,9 +39,11 @@ class ProfileView(View):
             return redirect('home')
         except Http404:
             return redirect('home')
-
         context = {
+            'username': f"{request.user.first_name} {request.user.last_name}",
             'user_profile': user_profile,
+            'isAdmin': request.user.role == 'Admin',
+            'self': username == None,
         }
 
         return render(request, 'profile_view/profile.html', context)

--- a/views/profile_view/views.py
+++ b/views/profile_view/views.py
@@ -40,11 +40,11 @@ class ProfileView(View):
         except Http404:
             return redirect('home')
         context = {
-            'request_username': f"{request.user.first_name} {request.user.last_name}",
+            'full_name': f"{request.user.first_name} {request.user.last_name}",
             'user_profile': user_profile,
             'isAdmin': request.user.role == 'Admin',
             'self': username == None,
-            'username': username,
+            'username': "" if username is None else username,
         }
 
         return render(request, 'profile_view/profile.html', context)

--- a/views/profile_view/views.py
+++ b/views/profile_view/views.py
@@ -40,10 +40,11 @@ class ProfileView(View):
         except Http404:
             return redirect('home')
         context = {
-            'username': f"{request.user.first_name} {request.user.last_name}",
+            'request_username': f"{request.user.first_name} {request.user.last_name}",
             'user_profile': user_profile,
             'isAdmin': request.user.role == 'Admin',
             'self': username == None,
+            'username': username,
         }
 
         return render(request, 'profile_view/profile.html', context)


### PR DESCRIPTION
Will work on unit test later, implement and enhance the header bar and designed the skeleton of profile-view page.

Header bar:
Explore will redirect to Search(not yet implemented ).
Notification will redirect to Notification(not yet implemented ).
Only admin can add course and create user
Press your own name will redirect to own profile page
Move logout button to header bar

Information section:
Redesign it
Edit button will redirect to /create-user/{{username}} when request person is admin and not in the self page. Consider all case. Admin can delete the account himself/herself.
Courses will implement later